### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,16 @@
+{% extends template.self %}
+
+{% block javascript %}
+    {{ super() }}
+    <!-- Hotjar Tracking Code -->"
+    <script>
+        (function(h,o,t,j,a,r) {
+            h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+            h._hjSettings={hjid:{{ config.pluginsConfig.hotjar.hjid }},hjsv:5};
+            a=o.getElementsByTagName('head')[0];
+            r=o.createElement('script');r.async=1;
+            r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+            a.appendChild(r);
+        })(window,document,'//static.hotjar.com/c/hotjar-','.js?sv=');
+    </script>
+{% endblock %}

--- a/index.js
+++ b/index.js
@@ -3,26 +3,6 @@ module.exports = {
     assets: "./book",
     js: [
       "plugin.js"
-    ],
-    html: {
-      "body:end": function() {
-        var config = this.options.pluginsConfig.hotjar || {};
-
-        if (!config.hjid) {
-          throw "Hotjar: option 'hjid' is required.";
-        }
-
-        return ""
-          + "<!-- Hotjar Tracking Code -->"
-          + "<script>(function(h,o,t,j,a,r){"
-          + "h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};"
-          + "h._hjSettings={hjid:"+config.hjid+",hjsv:5};"
-          + "a=o.getElementsByTagName('head')[0];"
-          + "r=o.createElement('script');r.async=1;"
-          + "r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;"
-          + "a.appendChild(r);"
-          + "})(window,document,'//static.hotjar.com/c/hotjar-','.js?sv=');</script>";
-      }
-    }
+    ]
   }
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
       "hjid": {
         "type": "number",
         "title": "Hotjar Analytics ID",
-        "required": false
+        "required": true
       }
     }
   }


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, the hooks used for this plugin will not be supported, since we are relying a lot more on the templating system to extend the books HTML.

The proposed PR has been tested with the new version.
Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

To ensure compatibility, your plugin's `package.json` should specify:

``` JSON
"engines": {
    "gitbook": ">=3.0.0-pre.0"
}
```

Kind regards,
Johan
